### PR TITLE
Allow connecting to the database from the Host machine - dev environment

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -39,6 +39,8 @@ services:
       context: ./db
       dockerfile: ./Dockerfile
     image: etoolsdev/etools-db:dev
+    ports:
+      - "5432:5432"
 #    volumes:
 #      - './postgres_data:/var/lib/postgresql/data'
 


### PR DESCRIPTION
Exposing port 5432 to the host allows us to view the database with tools like PgAdmin.