### PR TITLE
Fab update fixes

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -88,6 +88,7 @@ def update(quick=False):
     local('git fetch --all')
     # TODO should we use `develop` on unicef/etools-infra rather than `master`?
     local('git checkout master')
+    local('git merge origin/master')
     _update_submodules()
     if not quick:
         _frontend_deps_update()

--- a/fabfile.py
+++ b/fabfile.py
@@ -87,7 +87,7 @@ def _update_submodules():
 def update(quick=False):
     local('git fetch --all')
     # TODO should we use `develop` on unicef/etools-infra rather than `master`?
-    # local('git checkout --force %s' % branch)
+    local('git checkout master')
     _update_submodules()
     if not quick:
         _frontend_deps_update()

--- a/fabfile.py
+++ b/fabfile.py
@@ -81,7 +81,7 @@ def _update_submodules():
     # see https://stackoverflow.com/a/18799234/8207 for more information about submodule branch tracking
     local('git submodule sync')
     local('git submodule update --init --recursive --remote')
-    local('git submodule foreach -q --recursive \'branch="$(git config -f $toplevel/.gitmodules submodule.$name.branch)"; git checkout $branch\'')
+    local('git submodule foreach -q --recursive \'branch="$(git config -f $toplevel/.gitmodules submodule.$name.branch)"; git checkout $branch; git merge origin/$branch\'')
 
 
 def update(quick=False):


### PR DESCRIPTION
one of these days i'll get this right.

I noticed that my submodules were staying out of sync and what's been happening is that `git submodule update --init --recursive --remote` does properly update them, but the subsequent command was then checking out the *local* branch which didn't have the remote changes merged yet.

we could also eliminate this last step entirely if we don't mind everyone's submodules being on detached heads. given that we use pull requests for everything anyways i'm actually not sure whether being on the branch actually helps.

This also gets latest master on the infra repo