### PR TITLE
add `hstore` to list of installed extensions

### DIFF
--- a/db/load_db_data.sh
+++ b/db/load_db_data.sh
@@ -15,8 +15,9 @@ EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB
 for DB in template_postgis "$POSTGRES_DB"; do
-	echo "Loading PostGIS extensions into $DB"
+	echo "Loading extensions into $DB"
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
+		CREATE EXTENSION IF NOT EXISTS hstore;
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;


### PR DESCRIPTION
I suspect this was omitted as an oversight since it's present in the [backend setup](https://github.com/unicef/etools/blob/develop/db/load_db_data.sh#L16)

Among other things, this allows you to run tests in the docker environment.