### PR TITLE
don't sync submodules

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -79,7 +79,6 @@ def _frontend_deps_update():
 def _update_submodules():
     # TODO retry after timeouts
     # see https://stackoverflow.com/a/18799234/8207 for more information about submodule branch tracking
-    local('git submodule sync')
     local('git submodule update --init --recursive --remote')
     local('git submodule foreach -q --recursive \'branch="$(git config -f $toplevel/.gitmodules submodule.$name.branch)"; git checkout $branch; git merge origin/$branch\'')
 


### PR DESCRIPTION
at least in my own development workflow I use the ssh based urls in the submodules to push/pull to the remote repositories. the `git submodule sync` command overwrites them with the http urls from `.gitmodules` which I found to be a bit annoying, and I'm not sure why it should overwrite any local changes to your git submodule config on update. The subsequent `git submodule update --init --recursive` command should be fine for initialization if the submodules weren't already setup.

@ewheeler saw you [added this originally](https://github.com/unicef/etools-infra/commit/46418d7066a9f1aa1138558037c3de9798f686d6) - was there a workflow you thought `sync` was good for?